### PR TITLE
Add a newline to printed information after wallpaper is downloaded

### DIFF
--- a/wallhaven/cli.go
+++ b/wallhaven/cli.go
@@ -68,7 +68,7 @@ func Search(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("[download] %v", url)
+	fmt.Printf("[download] %v\n", url)
 	return nil
 }
 


### PR DESCRIPTION
This patch prevents terminal prompt to look bad. Screenshots are provided.
# Before this change
![before](https://github.com/user-attachments/assets/54ac9c45-3d9b-42bd-b79b-b0967a113d86)
# After this change
![after](https://github.com/user-attachments/assets/3a52dfee-eb16-4ed1-9547-c196e55db899)
